### PR TITLE
Add better earliness/delay calculation

### DIFF
--- a/frontend/src/EDR/components/Cells/TrainArrivalCell.tsx
+++ b/frontend/src/EDR/components/Cells/TrainArrivalCell.tsx
@@ -24,11 +24,11 @@ export const TrainArrivalCell: React.FC<Props> = ({
 }) => {
     const {t} = useTranslation();
     const [arrivalExpectedHours, arrivalExpectedMinutes] = ttRow.scheduled_arrival.split(":").map(value => parseInt(value));
-    const isArrivalNextDay = dateNow.getHours() > 20 && arrivalExpectedHours < 12;  // TODO: less but still clunky
-    const isArrivalPreviousDay = arrivalExpectedHours > 20 && dateNow.getHours() < 12; // TODO: less but still Clunky
-    const expectedArrival = getDateWithHourAndMinutes(arrivalExpectedHours, arrivalExpectedMinutes, serverTz);
-    const arrivalTimeDelay = getTimeDelay(isArrivalNextDay, isArrivalPreviousDay, dateNow, expectedArrival);
-    const departureTimeDelay = getTimeDelay(isArrivalNextDay, isArrivalPreviousDay, dateNow, expectedDeparture);
+    const isArrivalNextDay = dateNow.getHours() >= 20 && arrivalExpectedHours < 12;  // TODO: less but still clunky
+    const isArrivalPreviousDay = arrivalExpectedHours >= 20 && dateNow.getHours() < 12; // TODO: less but still Clunky
+    const expectedArrival = getDateWithHourAndMinutes(dateNow, arrivalExpectedHours, arrivalExpectedMinutes, isArrivalNextDay, isArrivalPreviousDay);
+    const arrivalTimeDelay = getTimeDelay(dateNow, expectedArrival);
+    const departureTimeDelay = getTimeDelay(dateNow, expectedDeparture);
 
 
     return (

--- a/frontend/src/EDR/components/TrainRow.tsx
+++ b/frontend/src/EDR/components/TrainRow.tsx
@@ -60,7 +60,9 @@ const TableRow: React.FC<Props> = (
     const trainHasPassedStation = initialPfHasPassedStation || (hasEnoughData ? closestStationid === post && currentDistance > previousDistance && distanceFromStation > postCfg.trainPosRange : false);
     const [departureExpectedHours, departureExpectedMinutes] = ttRow.scheduled_departure.split(":").map(value => parseInt(value));
     // console_log("Is next day ? " + ttRow.train_number, isNextDay);
-    const expectedDeparture = getDateWithHourAndMinutes(departureExpectedHours, departureExpectedMinutes, serverTz);
+    const isDepartureNextDay = dateNow.getHours() >= 20 && departureExpectedHours < 12;  // TODO: less but still clunky
+    const isDeparturePreviousDay = departureExpectedHours >= 20 && dateNow.getHours() < 12; // TODO: less but still Clunky
+    const expectedDeparture = getDateWithHourAndMinutes(dateNow, departureExpectedHours, departureExpectedMinutes, isDepartureNextDay, isDeparturePreviousDay);
     const trainMustDepart = !trainHasPassedStation && distanceFromStation < 1.5 && (subMinutes(expectedDeparture, 1) <= dateNow); // 1.5 for temporary zawierce freight fix
     const trainBadgeColor = configByType[ttRow.type]?.color ?? "purple";
     const secondaryPostData = ttRow?.secondaryPostsRows ?? [];

--- a/frontend/src/EDR/functions/__tests__/timeUtils.ts
+++ b/frontend/src/EDR/functions/__tests__/timeUtils.ts
@@ -3,35 +3,35 @@ describe("Time utils", () => {
     it("Calculates a simple delay on the same day", () => {
         const dateNow = new Date(2009, 12, 31, 23, 15);
         const dateExpected = new Date(2009, 12, 31, 23, 25);
-        const delayTime = getTimeDelay(false, false, dateExpected, dateNow);
+        const delayTime = getTimeDelay(dateExpected, dateNow);
         expect(delayTime).toBe(10);
     })
 
     it("Calculates an earlyness when the now is in next day and expected is previous day", () => {
         const dateNow =  new Date(2010, 1, 2, 0, 15);
         const dateExpected = new Date(2010, 1, 1, 23, 15);
-        const delayTime = getTimeDelay(true, false, dateNow, dateExpected);
+        const delayTime = getTimeDelay(dateNow, dateExpected);
         expect(delayTime).toBe(60);
     })
 
     it("Calculates a delay when the now is in previous day and expected is next day", () => {
         const dateNow = new Date(2010, 1, 1, 23, 15);
         const dateExpected = new Date(2010, 1, 2, 0, 15);
-        const delayTime = getTimeDelay(true, false, dateNow, dateExpected);
+        const delayTime = getTimeDelay(dateNow, dateExpected);
         expect(delayTime).toBe(-60);
     })
 
     it("Calculates a no delay no lateness when the now is in previous day and expected is previous day too", () => {
         const dateNow = new Date(2010, 1, 1, 22, 15);
         const dateExpected = new Date(2010, 1, 2, 22, 15);
-        const delayTime = getTimeDelay(true, false, dateNow, dateExpected);
+        const delayTime = getTimeDelay(dateNow, dateExpected);
         expect(delayTime).toBe(-1440);
     })
 
     it("Calculates a no delay no lateness when the now is in next day and expected is next day too", () => {
         const dateNow = new Date(2010, 1, 1, 22, 15);
         const dateExpected = new Date(2010, 1, 2, 22, 15);
-        const delayTime = getTimeDelay(true, false, dateNow, dateExpected);
+        const delayTime = getTimeDelay(dateNow, dateExpected);
         expect(delayTime).toBe(-1440);
     })
 })

--- a/frontend/src/EDR/functions/timeUtils.ts
+++ b/frontend/src/EDR/functions/timeUtils.ts
@@ -1,16 +1,17 @@
+import { addDays, differenceInMinutes, subDays } from "date-fns";
 import set from "date-fns/set";
-import {nowUTC} from "../../utils/date";
 
-const minutesInADay = 1440;
+export const getDateWithHourAndMinutes = (dateNow: Date, expectedHours: number, expectedMinutes: number, isArrivalNextDay: boolean, isArrivalPreviousDay: boolean) => {
+    if (isArrivalNextDay) {
+        return set(addDays(dateNow, 1), {hours: expectedHours, minutes: expectedMinutes})
+    } else if (isArrivalPreviousDay) {
+        return set(subDays(dateNow, 1), {hours: expectedHours, minutes: expectedMinutes})
+    } else {
+        return set(dateNow, {hours: expectedHours, minutes: expectedMinutes});
+    }
+}
 
-export const getDateWithHourAndMinutes = (expectedHours: number, expectedMinutes: number, tz: string) =>
-    set(nowUTC(tz), {hours: expectedHours, minutes: expectedMinutes});
-
-export const getTimeDelay = (isArrivalNextDay: boolean, isArrivalPreviousDay: boolean, dateNow: Date, expected: Date) =>
-    ((isArrivalNextDay && dateNow.getHours() < 20 ? 1 : 0) * minutesInADay)
-    + ((isArrivalNextDay && dateNow.getHours() > 20 ? 1 : 0) * -minutesInADay)
-    + ((isArrivalPreviousDay && dateNow.getHours() > 20 ? 1 : 0) * minutesInADay)
-    + ((isArrivalPreviousDay && dateNow.getHours() < 20 ? 1 : 0) * -minutesInADay)
-    + ((dateNow.getHours() - expected.getHours()) * 60) + (dateNow.getMinutes() - expected.getMinutes());
+export const getTimeDelay = (dateNow: Date, expected: Date) =>
+    differenceInMinutes(dateNow, expected);
 
 


### PR DESCRIPTION
Reimplemented an easier way to calculate earliness or delayed status.

Adjusted code to handle edge cases better. For example:
- Train arrives before midnight but leaves after midnight
- Long-haul train starts before 21:00

Closes https://github.com/DKFN/edr-issues/issues/99