### PR TITLE
Adjust buttons on dark mode on select server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@mui/material": "^5.11.10",
     "classnames": "^2.3.2",
     "country-flag-icons": "^1.5.5",
     "date-fns": "^2.29.3",
@@ -12,6 +13,7 @@
     "flowbite": "^1.5.5",
     "flowbite-react": "^0.3.7",
     "hacktimer": "^1.1.3",
+    "i18next": "^22.4.10",
     "i18next-browser-languagedetector": "^7.0.1",
     "i18next-http-backend": "^2.1.1",
     "lodash": "^4.17.21",

--- a/frontend/src/SelectMenu/Layout.tsx
+++ b/frontend/src/SelectMenu/Layout.tsx
@@ -87,31 +87,31 @@ export const SelectMenuLayout: React.FC<Props> = ({children, title, isWebpSuppor
 
         <div style={{backgroundImage: "url('"+background+"')", backgroundSize: "cover"}} className="min-h-screen">
             <div className="pl-4 pt-4 flex justify-end mr-16">
-                <Button size="xs" color="gray" className="mx-2" href="https://forum.simrail.eu/">
+                <Button size="xs" color="light" className="mx-2" href="https://forum.simrail.eu/">
                     <span className="inline-flex items-center "><img src={SGCS} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Official</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2" href="https://discord.com/invite/XgJpXpG2Eu">
+                <Button size="xs" color="light" className="mx-2" href="https://discord.com/invite/XgJpXpG2Eu">
                     <span className="inline-flex items-center "><img src={SGCS} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Global</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2" href="https://simrail.fr/discord">
+                <Button size="xs" color="light" className="mx-2" href="https://simrail.fr/discord">
                     <span className="inline-flex items-center "><img src={SRFR} height={16} width={16} alt="Community logo"/>&nbsp;Simrail France</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2" href="https://discord.gg/DztnvgePXw">
+                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/DztnvgePXw">
                     <span className="inline-flex items-center "><img src={OFPMafia} height={16} width={16} alt="Community logo"/>&nbsp;OFPMafia CZ/SK</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2" href="https://discord.gg/A63hJphHQ4">
+                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/A63hJphHQ4">
                     <span className="inline-flex items-center "><img src={SRDE} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Germany</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2" href="https://discord.gg/5cdpDv2nT8">
+                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/5cdpDv2nT8">
                     <span className="inline-flex items-center "><img src={SRIT} height={16} width={16} alt="Community logo"/>&nbsp;Simrail ITA</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2">
+                <Button size="xs" color="light" className="mx-2">
                     <span className="inline-flex items-center "><CN height={16} width={16}/>&nbsp;CN-BX-3N</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2" href="https://discord.gg/Kyte5PB6xf">
+                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/Kyte5PB6xf">
                     <span className="inline-flex items-center "><img src={SGCS} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Russian Speaking</span>
                 </Button>
-                <Button size="xs" color="gray" className="mx-2">
+                <Button size="xs" color="light" className="mx-2">
                     <span className="inline-flex items-center "><PL height={16} width={16}/>&nbsp;Invis</span>
                 </Button>
             </div>

--- a/frontend/src/SelectMenu/Layout.tsx
+++ b/frontend/src/SelectMenu/Layout.tsx
@@ -86,32 +86,32 @@ export const SelectMenuLayout: React.FC<Props> = ({children, title, isWebpSuppor
         </Navbar>
 
         <div style={{backgroundImage: "url('"+background+"')", backgroundSize: "cover"}} className="min-h-screen">
-            <div className="pl-4 pt-4 flex justify-end mr-16">
-                <Button size="xs" color="light" className="mx-2" href="https://forum.simrail.eu/">
+            <div className="pl-4 pt-4 flex justify-center mr-0 flex-wrap lg:justify-end lg:mr-16 lg:flex-nowrap">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://forum.simrail.eu/">
                     <span className="inline-flex items-center "><img src={SGCS} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Official</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2" href="https://discord.com/invite/XgJpXpG2Eu">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://discord.com/invite/XgJpXpG2Eu">
                     <span className="inline-flex items-center "><img src={SGCS} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Global</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2" href="https://simrail.fr/discord">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://simrail.fr/discord">
                     <span className="inline-flex items-center "><img src={SRFR} height={16} width={16} alt="Community logo"/>&nbsp;Simrail France</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/DztnvgePXw">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://discord.gg/DztnvgePXw">
                     <span className="inline-flex items-center "><img src={OFPMafia} height={16} width={16} alt="Community logo"/>&nbsp;OFPMafia CZ/SK</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/A63hJphHQ4">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://discord.gg/A63hJphHQ4">
                     <span className="inline-flex items-center "><img src={SRDE} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Germany</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/5cdpDv2nT8">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://discord.gg/5cdpDv2nT8">
                     <span className="inline-flex items-center "><img src={SRIT} height={16} width={16} alt="Community logo"/>&nbsp;Simrail ITA</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0">
                     <span className="inline-flex items-center "><CN height={16} width={16}/>&nbsp;CN-BX-3N</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2" href="https://discord.gg/Kyte5PB6xf">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0" href="https://discord.gg/Kyte5PB6xf">
                     <span className="inline-flex items-center "><img src={SGCS} height={16} width={16} alt="Community logo"/>&nbsp;Simrail Russian Speaking</span>
                 </Button>
-                <Button size="xs" color="light" className="mx-2">
+                <Button size="xs" color="light" className="mx-2 my-2 lg:my-0">
                     <span className="inline-flex items-center "><PL height={16} width={16}/>&nbsp;Invis</span>
                 </Button>
             </div>
@@ -122,7 +122,7 @@ export const SelectMenuLayout: React.FC<Props> = ({children, title, isWebpSuppor
                 </div>
             </div>
         </div>
-        <div className="text-center mt-4">
+        <div className="text-center py-4">
             {t("FOOTER_version")} 1.2 - {t("FOOTER_screenshots_by")} MilanSVK - {t("FOOTER_thanks")} ❤️ - {t("FOOTER_not_official")} - <a href="https://github.com/simrail/EDR">Github project</a>
         </div>
     </div>;

--- a/frontend/src/SelectMenu/Layout.tsx
+++ b/frontend/src/SelectMenu/Layout.tsx
@@ -122,7 +122,7 @@ export const SelectMenuLayout: React.FC<Props> = ({children, title, isWebpSuppor
                 </div>
             </div>
         </div>
-        <div className="text-center py-4">
+        <div className="text-center p-4">
             {t("FOOTER_version")} 1.2 - {t("FOOTER_screenshots_by")} MilanSVK - {t("FOOTER_thanks")} ❤️ - {t("FOOTER_not_official")} - <a href="https://github.com/simrail/EDR">Github project</a>
         </div>
     </div>;


### PR DESCRIPTION
- On [EDR Server List (dark mode)](https://edr.simrail.app/) there is an transparency issue with discord servers buttons. Light mode remain unaffected.
- On mobile & tablet (below 1023px) I've fixed the positions (for discord servers buttons) as it was overflowing.
- On footer was missing space below (desktop and mobile), left and right (on mobile)
- Running the project also was complaining about `@mui/material` and `i18next` didn't exist in node_modules so I've added in package.json

### Before the fixes
#### Dark Mode (issue)
<img width="1792" alt="Screenshot 2023-02-21 at 16 07 57" src="https://user-images.githubusercontent.com/28097268/220368643-43c8302f-8517-424f-ab94-d82fd7e6215a.png">

#### Light Mode (unaffected)
<img width="1791" alt="Screenshot 2023-02-21 at 16 16 06" src="https://user-images.githubusercontent.com/28097268/220369521-57bc8a43-e88f-400e-a11b-68f4f5774939.png">

#### Mobile (issue)
<img width="615" alt="Screenshot 2023-02-21 at 16 34 28" src="https://user-images.githubusercontent.com/28097268/220373826-4877d26e-c288-4b51-a214-9fd5fa786796.png">

#### Footer (issue)
<img width="1792" alt="Screenshot 2023-02-21 at 16 36 44" src="https://user-images.githubusercontent.com/28097268/220374456-fe34683b-fe37-4b11-a502-f331c6ec215f.png">


### After the fixes
#### Dark Mode (fixed)
<img width="1792" alt="Screenshot 2023-02-21 at 16 07 47" src="https://user-images.githubusercontent.com/28097268/220368706-ca7f7f88-75d4-4fea-b544-33431c8d9626.png">

#### Light Mode (unaffected)
<img width="1792" alt="Screenshot 2023-02-21 at 16 14 12" src="https://user-images.githubusercontent.com/28097268/220369043-d2e182c9-b662-4f31-b4a0-207b6dfcce02.png">

#### Mobile (fixed)
<img width="616" alt="Screenshot 2023-02-21 at 16 34 54" src="https://user-images.githubusercontent.com/28097268/220373909-2a263c72-46d1-45a2-beb4-db40366e0b2a.png">

#### Footer (fixed)
<img width="1792" alt="Screenshot 2023-02-21 at 16 37 14" src="https://user-images.githubusercontent.com/28097268/220374586-31785a3e-2392-44eb-8fe7-b47af231baf6.png">
