### PR TITLE
Add snap to scroll to table rows

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.bunny.net/css?family=Open+Sans:wght@600&display=swap" rel="stylesheet">
     <title>EDR 1.2</title>
   </head>
-  <body style="overflow-y: scroll">
+  <body>
     <noscript>You need to enable JavaScript to run this app.<br /></noscript>
     <div id="root"></div>
     <!--

--- a/frontend/src/EDR/components/Table.tsx
+++ b/frontend/src/EDR/components/Table.tsx
@@ -86,9 +86,9 @@ export const EDRTable: React.FC<Props> = ({
             filterConfig={filterConfig}
             setFilterConfig={setFilterConfig}
         />
-        <div>
+        <div className="child:snap-y child:snap-mandatory child:overflow-y-scroll child:h-[calc(100vh-166px)]">
             <Table striped={true}>
-            <Table.Body className="overflow-x-auto">
+            <Table.Body>
                 {timetable.length > 0
                     ? timetable
                         .filter((tt) => filter ? 

--- a/frontend/src/EDR/components/Table.tsx
+++ b/frontend/src/EDR/components/Table.tsx
@@ -11,6 +11,7 @@ import {FilterConfig, TimeTableRow} from "..";
 import { DetailedTrain } from "../functions/trainDetails";
 import {format} from "date-fns";
 import {TrainTimetableModal} from "./TrainTimetableModal";
+import classNames from "classnames";
 
 export type Bounds = {
     firstColBounds: RectReadOnly;
@@ -86,7 +87,10 @@ export const EDRTable: React.FC<Props> = ({
             filterConfig={filterConfig}
             setFilterConfig={setFilterConfig}
         />
-        <div className="child:snap-y child:snap-mandatory child:overflow-y-scroll child:h-[calc(100vh-166px)]">
+        <div className={classNames(
+            "child:snap-y child:snap-mandatory child:overflow-y-scroll ",
+                streamMode ? "child:h-[calc(100vh-102px)]" : "child:h-[calc(100vh-166px)]"
+            )}>
             <Table striped={true}>
             <Table.Body>
                 {timetable.length > 0

--- a/frontend/src/EDR/components/TableHead.tsx
+++ b/frontend/src/EDR/components/TableHead.tsx
@@ -3,7 +3,7 @@ import {useTranslation} from "react-i18next";
 import classNames from "classnames";
 import {Bounds} from "./Table";
 
-const tableHeadCommonClassName = "p-4"
+const tableHeadCommonClassName = "p-4 max-h-[56px] truncate"
 export const TableHead: React.FC<Bounds> = ({firstColBounds, secondColBounds, thirdColBounds, fourthColBounds, fifthColBounds, sixthColBounds, seventhColBounds, showStopColumn}) => {
     const {t} = useTranslation();
     if (!firstColBounds) return null;

--- a/frontend/src/EDR/components/TrainRow.tsx
+++ b/frontend/src/EDR/components/TrainRow.tsx
@@ -90,7 +90,7 @@ const TableRow: React.FC<Props> = (
     const expectedArrivalIninutes = (expectedArrival.getHours() * 60 + expectedArrival.getMinutes()) - (dateNow.getHours() * 60 + dateNow.getMinutes());
     if (filterConfig.maxTime && Math.abs(expectedArrivalIninutes) > filterConfig.maxTime) return null;
 
-    return <Table.Row className="dark:text-gray-100 light:text-gray-800" style={{opacity: trainHasPassedStation ? 0.5 : 1}} data-timeoffset={timeOffset}>
+    return <Table.Row className="snap-start dark:text-gray-100 light:text-gray-800" style={{opacity: trainHasPassedStation ? 0.5 : 1}} data-timeoffset={timeOffset}>
         <TrainInfoCell
             ttRow={ttRow}
             trainDetails={trainDetails}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,6 +8,10 @@ module.exports = {
     extend: {},
   },
   plugins: [
-    require('flowbite/plugin')
+    require('flowbite/plugin'),
+    function ({ addVariant }) {
+      addVariant('child', '& > *');
+      addVariant('child-hover', '& > *:hover');
+    }
   ],
 }


### PR DESCRIPTION
Based on this issue: https://github.com/simrail/EDR/issues/41

- I've managed to add snap to scroll on tables with tailwind unfortunately because of https://flowbite-react.com/tables have an inside wrapper that I cannot add a class I had to add children classes with tailwind.

![ezgif-1-8562fb675b](https://user-images.githubusercontent.com/28097268/220453174-45cc52a8-aaf9-4771-9990-41a41d87da33.gif)
