### PR TITLE
Sort the timetable from current hour with one hour earlier to next day

### DIFF
--- a/frontend/src/EDR/components/DateTimeDisplay.tsx
+++ b/frontend/src/EDR/components/DateTimeDisplay.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useTranslation} from "react-i18next";
-import {formatTime, nowUTC} from "../../utils/date";
+import {timeOptions, formatTime, nowUTC} from "../../utils/date";
 
 type Props = {serverTzOffset: number, serverCode: string};
 
@@ -16,7 +16,7 @@ export const DateTimeDisplay: React.FC<Props> = ({serverTzOffset, serverCode}) =
     }, [serverTzOffset])
 
     return <div className="text-center">
-        <span className="mr-2 text-xl">{formatTime(dt, i18n.language)}</span><br />
+        <span className="mr-2 text-xl">{formatTime(dt, i18n.language, timeOptions)}</span><br />
         <span className="text-xs">{serverCode.toUpperCase()} / (UTC {serverTzOffset})</span>
     </div>
 }

--- a/frontend/src/EDR/components/Table.tsx
+++ b/frontend/src/EDR/components/Table.tsx
@@ -48,6 +48,7 @@ export const EDRTable: React.FC<Props> = ({
     const [mapModalTrainId, setMapModalTrainId] = React.useState<string | undefined>();
     const [timetableModalTrainId, setTimetableModalTrainId] = React.useState<string | undefined>();
     const [streamMode, setStreamMode] = React.useState(false);
+    const [selectedRow, setSelectedRow] = React.useState<number | null>(null);
 
     const [headerFirstColRef, firstColBounds] = useMeasure();
     const [headerSecondColRef, secondColBounds] = useMeasure();
@@ -114,12 +115,15 @@ export const EDRTable: React.FC<Props> = ({
                             // If any train numbers match up, filter for it
                             .some((train_filter) => tt.train_number.startsWith(train_filter)) : true)
                         .filter((tt) => filterConfig.onlyOnTrack ? !!trainsWithDetails[tt.train_number] : true)
-                        .map((tr) =>
+                        .map((tr, index: number) =>
                     <TableRow
                         key={tr.train_number + "_" + tr.from + "_" + tr.to}
                         ttRow={tr}
+                        index={index}
+                        selectedRow={selectedRow}
                         serverTzOffset={serverTzOffset}
                         post={post}
+                        setSelectedRow={setSelectedRow}
                         firstColRef={ headerFirstColRef}
                         secondColRef={headerSecondColRef}
                         thirdColRef={headerThirdColRef}

--- a/frontend/src/EDR/components/Table.tsx
+++ b/frontend/src/EDR/components/Table.tsx
@@ -12,6 +12,7 @@ import { DetailedTrain } from "../functions/trainDetails";
 import {format} from "date-fns";
 import {TrainTimetableModal} from "./TrainTimetableModal";
 import i18n from "../../i18n";
+import { getTimetableStartingFromHour } from "../functions/trainsTable";
 
 export type Bounds = {
     firstColBounds: RectReadOnly;
@@ -70,33 +71,11 @@ export const EDRTable: React.FC<Props> = ({
     if (!trainsWithDetails || !post) return null;
     const postCfg = postConfig[post];
     const showStopColumn = timetable.length > 0 && timetable.some((row: any) => row.platform || Math.ceil(parseInt(row.layover)) !== 0);
-
-    const getTimetableStartingFromHour = (timetable: TimeTableRow[], startHour: string) => {      
-        // Find the index of the first time in the timetable that is equal to or
-        // greater than the start hour
-        const startIndex = timetable.findIndex((time: TimeTableRow) => time.scheduled_arrival >= startHour);
-        
-        if (startIndex === -1) {
-          // If there is no time in the timetable that is equal to or greater than the
-          // start hour, add the times from the beginning of the 24-hour period up to
-          // (but not including) the start hour, as well as all times from the start
-          // hour until the end of the 24-hour period
-            return [
-                ...timetable.slice(0, timetable.findIndex((time: TimeTableRow) => time.scheduled_arrival === startHour)),
-                ...timetable.slice(timetable.findIndex((time: TimeTableRow) => time.scheduled_arrival === startHour))
-            ];
-        } else {
-          // If there is a time in the timetable that is equal to or greater than the
-          // start hour, return a new array that starts from the start index and
-          // includes all times up to the end of the 24-hour period, as well as all
-          // times from the beginning of the 24-hour period up to (but not including)
-          // the start index
-            return [
-                ...timetable.slice(startIndex),
-                ...timetable.slice(0, startIndex)
-            ];
-        }
-    }
+    const timetableStartHour = formatTime(nowUTC(serverTzOffset, 1), i18n.language, {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+    });
 
     return <div>
         <SimRailMapModal serverCode={serverCode} trainId={mapModalTrainId} setModalTrainId={setMapModalTrainId} />
@@ -120,11 +99,7 @@ export const EDRTable: React.FC<Props> = ({
                 {timetable.length > 0
                     ? getTimetableStartingFromHour(
                         timetable,
-                        formatTime(nowUTC(serverTzOffset, 1), i18n.language, {
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            hour12: false
-                        }))
+                        timetableStartHour)
                         .filter((tt) => filter ? 
                             // Remove spaces, trim not enough since humans usually use space after a separator
                             filter.replace(/\s+/g, '')

--- a/frontend/src/EDR/components/Table.tsx
+++ b/frontend/src/EDR/components/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import {Table, Spinner} from "flowbite-react";
 import {searchSeparator} from "../../config";
 import TableRow from "./TrainRow";
@@ -66,7 +66,7 @@ export const EDRTable: React.FC<Props> = ({
     }
 
     const dt = nowUTC(serverTzOffset);
-  
+
     if (!trainsWithDetails || !post) return null;
     const postCfg = postConfig[post];
     const showStopColumn = timetable.length > 0 && timetable.some((row: any) => row.platform || Math.ceil(parseInt(row.layover)) !== 0);

--- a/frontend/src/EDR/components/TrainRow.tsx
+++ b/frontend/src/EDR/components/TrainRow.tsx
@@ -21,6 +21,7 @@ export const tableCellCommonClassnames = (streamMode: boolean = false) => stream
 type Props = {
     setModalTrainId: React.Dispatch<React.SetStateAction<string | undefined>>,
     setTimetableTrainId: React.Dispatch<React.SetStateAction<string | undefined>>,
+    setSelectedRow: React.Dispatch<React.SetStateAction<number | null>>,
     ttRow: TimeTableRow,
     timeOffset: number,
     trainDetails: DetailedTrain,
@@ -38,12 +39,15 @@ type Props = {
     showOnlyApproachingTrains: boolean;
     streamMode: boolean;
     filterConfig: FilterConfig;
+    index: number;
+    selectedRow: number | null;
 }
 
 const TableRow: React.FC<Props> = (
     {setModalTrainId, ttRow, timeOffset, trainDetails, serverTzOffset, post,
         firstColRef, secondColRef, thirdColRef, headerFourthColRef, headerFifthColRef, headerSixthhColRef, headerSeventhColRef,
-        playSoundNotification, isWebpSupported, showOnlyApproachingTrains, streamMode, setTimetableTrainId, filterConfig
+        playSoundNotification, isWebpSupported, showOnlyApproachingTrains, streamMode, setTimetableTrainId, filterConfig, index,
+        selectedRow, setSelectedRow
     }: Props
 ) => {
     const dateNow = nowUTC(serverTzOffset);
@@ -90,7 +94,14 @@ const TableRow: React.FC<Props> = (
     const expectedArrivalIninutes = (expectedArrival.getHours() * 60 + expectedArrival.getMinutes()) - (dateNow.getHours() * 60 + dateNow.getMinutes());
     if (filterConfig.maxTime && Math.abs(expectedArrivalIninutes) > filterConfig.maxTime) return null;
 
-    return <Table.Row className="snap-start dark:text-gray-100 light:text-gray-800" style={{opacity: trainHasPassedStation ? 0.5 : 1}} data-timeoffset={timeOffset}>
+    return <Table.Row
+        onClick={() => setSelectedRow(index !== selectedRow ? index : null)} 
+        className={`
+            cursor-pointer snap-start dark:text-gray-100 light:text-gray-800 hover:bg-gray-200 dark:hover:bg-gray-600 
+            ${trainHasPassedStation ? 'opacity-50' : 'opacity-100'}
+            ${selectedRow === index ? 'odd:bg-gray-300 even:bg-gray-300 dark:odd:bg-gray-500 dark:even:bg-gray-500' : ''}
+        `} data-timeoffset={timeOffset}
+    >
         <TrainInfoCell
             ttRow={ttRow}
             trainDetails={trainDetails}

--- a/frontend/src/EDR/components/TrainTimetableModal.tsx
+++ b/frontend/src/EDR/components/TrainTimetableModal.tsx
@@ -33,7 +33,10 @@ const TrainTimetableBody: React.FC<{timetable?: any[], closestStation?: string, 
             </Table.Head>
             <Table.Body>
                 {timetable.map((ttRow, index: number) => (
-                    <Table.Row key={ttRow.station}>
+                    <Table.Row 
+                        className="hover:bg-gray-200 dark:hover:bg-gray-600"
+                        key={ttRow.station}
+                    >
                         <Table.Cell className="relative">
                             <div className="flex flex-col">
                                 <TrainTimetableTimeline isAtTheStation={ttRow.station === closestStation} itemIndex={index} closestStationIndex={closestStationIndex} />

--- a/frontend/src/EDR/functions/trainsTable.ts
+++ b/frontend/src/EDR/functions/trainsTable.ts
@@ -1,0 +1,28 @@
+import { TimeTableRow } from "..";
+
+export const getTimetableStartingFromHour = (timetable: TimeTableRow[], startHour: string) => {      
+    // Find the index of the first time in the timetable that is equal to or
+    // greater than the start hour
+    const startIndex = timetable.findIndex((time: TimeTableRow) => time.scheduled_arrival >= startHour);
+    
+    if (startIndex === -1) {
+      // If there is no time in the timetable that is equal to or greater than the
+      // start hour, add the times from the beginning of the 24-hour period up to
+      // (but not including) the start hour, as well as all times from the start
+      // hour until the end of the 24-hour period
+        return [
+            ...timetable.slice(0, timetable.findIndex((time: TimeTableRow) => time.scheduled_arrival === startHour)),
+            ...timetable.slice(timetable.findIndex((time: TimeTableRow) => time.scheduled_arrival === startHour))
+        ];
+    } else {
+      // If there is a time in the timetable that is equal to or greater than the
+      // start hour, return a new array that starts from the start index and
+      // includes all times up to the end of the 24-hour period, as well as all
+      // times from the beginning of the 24-hour period up to (but not including)
+      // the start index
+        return [
+            ...timetable.slice(startIndex),
+            ...timetable.slice(0, startIndex)
+        ];
+    }
+}

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,21 +1,21 @@
 import utcToZonedTime from 'date-fns-tz/utcToZonedTime'
 import {addDays, addHours} from "date-fns";
 
-const options: Intl.DateTimeFormatOptions = {
+export const timeOptions: Intl.DateTimeFormatOptions = {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
     hour12: false
 };
  // TODO: Take UTC offset from API now. And then shift the hours by the UTC offset value instead of taking TZ
-export const nowUTC = (serverTzOffset: number = 0) => {
+export const nowUTC = (serverTzOffset: number = 0, addDelay?: number) => {
     const now = new Date();
     return addHours(utcToZonedTime(Date.UTC(now.getUTCFullYear(),now.getUTCMonth(), now.getUTCDate() ,
-        now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds(), now.getUTCMilliseconds()), "Europe/London"), serverTzOffset)
+        addDelay ? now.getUTCHours() - addDelay : now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds(), now.getUTCMilliseconds()), "Europe/London"), serverTzOffset)
 }
 
 // We don't care about the date, only time
-export const formatTime = (date: Date, language: string) => {
+export const formatTime = (date: Date, language: string, options?: Intl.DateTimeFormatOptions) => {
     if (!(date instanceof Date)) {
 		return '-';
 	}


### PR DESCRIPTION
Fixes: https://github.com/simrail/EDR/issues/58, https://github.com/simrail/EDR/issues/43

- The timetable starts now from the current hour with 1 hour earlier.
- Added a hover effect when you walk through the table rows and an active state when you click on a row

For example if now is 21:00 the timetable will starts from 20:00 until next day at 20:00

![image](https://user-images.githubusercontent.com/28097268/220491037-dc743fd8-2c0c-4536-818f-a43f52d3e185.png)
