### PR TITLE
Add timeline progress for each locomotive to dispatcher timetable (WIP)

### DIFF
--- a/frontend/src/EDR/components/Table.tsx
+++ b/frontend/src/EDR/components/Table.tsx
@@ -73,7 +73,7 @@ export const EDRTable: React.FC<Props> = ({
 
     return <div>
         <SimRailMapModal serverCode={serverCode} trainId={mapModalTrainId} setModalTrainId={setMapModalTrainId} />
-        <TrainTimetableModal trainId={timetableModalTrainId} setModalTrainId={setTimetableModalTrainId} />
+        <TrainTimetableModal trainDetails={timetableModalTrainId ? trainsWithDetails[timetableModalTrainId] : undefined} setModalTrainId={setTimetableModalTrainId} />
         <Header
             serverTzOffset={serverTzOffset}
             serverCode={serverCode}

--- a/frontend/src/EDR/components/TrainTimetableModal.tsx
+++ b/frontend/src/EDR/components/TrainTimetableModal.tsx
@@ -68,7 +68,7 @@ export const TrainTimetableModal: React.FC<Props> = React.memo(({trainDetails, s
             </div>
         </Modal.Header>
         <Modal.Body>
-            <div className="max-h-[700px] overflow-y-scroll">
+            <div className="max-h-[700px] overflow-y-scroll child:px-2">
                 <TrainTimetableBody timetable={trainTimetable} closestStation={trainDetails.closestStation} />
             </div>
         </Modal.Body>

--- a/frontend/src/EDR/components/TrainTimetableModal.tsx
+++ b/frontend/src/EDR/components/TrainTimetableModal.tsx
@@ -34,8 +34,8 @@ const TrainTimetableBody: React.FC<{timetable?: any[], closestStation?: string, 
             <Table.Body>
                 {timetable.map((ttRow, index: number) => (
                     <Table.Row key={ttRow.station}>
-                        <Table.Cell className="relative text-right">
-                            <div className="flex flex-col w-3">
+                        <Table.Cell className="relative">
+                            <div className="flex flex-col">
                                 <TrainTimetableTimeline isAtTheStation={ttRow.station === closestStation} itemIndex={index} closestStationIndex={closestStationIndex} />
                                 {ttRow.scheduled_arrival_hour?.length > 0 && (
                                     <>

--- a/frontend/src/EDR/components/TrainTimetableModal.tsx
+++ b/frontend/src/EDR/components/TrainTimetableModal.tsx
@@ -2,15 +2,19 @@ import {Modal, Table} from "flowbite-react";
 import React from "react";
 import {getTrainTimetable} from "../../api/api";
 import {Spinner} from "flowbite-react/lib/esm/components/Spinner";
+import { DetailedTrain } from "../functions/trainDetails";
+import TrainTimetableTimeline from "./TrainTimetableTimeline";
 
 type Props = {
-    trainId?: string;
+    trainDetails?: DetailedTrain | undefined;
     setModalTrainId: (trainId: string | undefined) => void;
 }
 
-const TrainTimetableBody: React.FC<{timetable?: any[]}> = ({timetable}) => {
+const TrainTimetableBody: React.FC<{timetable?: any[], closestStation?: string}> = ({timetable, closestStation}) => {
     if (!timetable) return <Spinner />
     if (timetable.length === 0) return <>&nbsp; Some trains may be missing during beta</>
+    const closestStationIndex = timetable.findIndex(ttRow => ttRow.station === closestStation);
+
     return (
         <Table className="max-h-[700px]" striped>
             <Table.Head>
@@ -19,11 +23,17 @@ const TrainTimetableBody: React.FC<{timetable?: any[]}> = ({timetable}) => {
                 <Table.HeadCell>Stop</Table.HeadCell>
             </Table.Head>
             <Table.Body>
-                {timetable.map((ttRow) => (
+                {timetable.map((ttRow, index: number) => (
                     <Table.Row key={ttRow.station}>
-                        <Table.Cell>
-                            <div className="flex flex-col">
-                                {ttRow.scheduled_arrival_hour} <br />
+                        <Table.Cell className="relative text-right">
+                            <div className="flex flex-col w-3">
+                                <TrainTimetableTimeline isAtTheStation={ttRow.station === closestStation} itemIndex={index} closestStationIndex={closestStationIndex} />
+                                {ttRow.scheduled_arrival_hour?.length > 0 && (
+                                    <>
+                                        {ttRow.scheduled_arrival_hour}
+                                        <br />
+                                    </>
+                                )}
                                 {ttRow.scheduled_departure_hour}
                             </div>
                         </Table.Cell>
@@ -40,26 +50,26 @@ const TrainTimetableBody: React.FC<{timetable?: any[]}> = ({timetable}) => {
     )
 }
 
-export const TrainTimetableModal: React.FC<Props> = React.memo(({trainId, setModalTrainId}) => {
+export const TrainTimetableModal: React.FC<Props> = React.memo(({trainDetails, setModalTrainId}) => {
     const [trainTimetable, setTrainTimetable] = React.useState();
 
     React.useEffect(() => {
-        if (trainId === undefined)  {
+        if (trainDetails?.TrainNoLocal === undefined)  {
             setTrainTimetable(undefined);
             return;
         }
-        getTrainTimetable(trainId!).then(setTrainTimetable);
-    }, [trainId]);
+        getTrainTimetable(trainDetails.TrainNoLocal).then(setTrainTimetable);
+    }, [trainDetails]);
 
-    return trainId ? <Modal className="z-20" show={!!trainId} size="7xl" onClose={() => setModalTrainId(undefined)} position="bottom-center" style={{zIndex: 999999}}>
+    return trainDetails?.TrainNoLocal ? <Modal className="z-20" show={!!trainDetails?.TrainNoLocal} size="7xl" onClose={() => setModalTrainId(undefined)} position="bottom-center" style={{zIndex: 999999}}>
         <Modal.Header>
             <div className="flex justify-around">
-                <span>N° {trainId} (Beta)</span>
+                <span>N° {trainDetails?.TrainNoLocal} (Beta)</span>
             </div>
         </Modal.Header>
         <Modal.Body>
             <div className="max-h-[700px] overflow-y-scroll">
-                <TrainTimetableBody timetable={trainTimetable} />
+                <TrainTimetableBody timetable={trainTimetable} closestStation={trainDetails.closestStation} />
             </div>
         </Modal.Body>
     </Modal> : null;

--- a/frontend/src/EDR/components/TrainTimetableTimeline.tsx
+++ b/frontend/src/EDR/components/TrainTimetableTimeline.tsx
@@ -15,7 +15,10 @@ const TrainTimetableTimeline: React.FC<Props> = ({ itemIndex, closestStationInde
             )}
             <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} left-0 rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 border-white dark:border-slate-700 z-10`}></div>
             {isAtTheStation && (
-                <div className="absolute w-4 h-4 bg-green-400 border-2 border-green-300 rounded-full top-1/2 -translate-y-1/2 left-0 z-10 dark:bg-green-500 dark:border-green-400"></div>
+                <span className="flex h-4 w-4 absolute left-0 top-1/2 -translate-y-1/2 z-10">
+                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+                    <span className="relative inline-flex rounded-full h-4 w-4 bg-green-400"></span>
+                </span>
             )}
         </>
     )

--- a/frontend/src/EDR/components/TrainTimetableTimeline.tsx
+++ b/frontend/src/EDR/components/TrainTimetableTimeline.tsx
@@ -15,7 +15,7 @@ const TrainTimetableTimeline: React.FC<Props> = ({ itemIndex, closestStationInde
                     <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} -top-[45%] left-1.5`}></div>
                 </>
             )}
-            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} left-0 rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 ${itemIndex % 2 ? 'border-gray-50 dark:border-gray-700' : 'border-white dark:border-gray-800' } z-10`}></div>
+            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} left-0 rounded-full top-1/2 -translate-y-1/2 border-2 ${itemIndex % 2 ? 'border-gray-50 dark:border-gray-700' : 'border-white dark:border-gray-800' } z-10`}></div>
             {isAtTheStation && (
                 <span className="flex h-4 w-4 absolute left-0 top-1/2 -translate-y-1/2 z-10">
                     <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>

--- a/frontend/src/EDR/components/TrainTimetableTimeline.tsx
+++ b/frontend/src/EDR/components/TrainTimetableTimeline.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+type Props = {
+    itemIndex: number;
+    closestStationIndex: number;
+    isAtTheStation: boolean;
+}
+
+const TrainTimetableTimeline: React.FC<Props> = ({ itemIndex, closestStationIndex, isAtTheStation }) => {
+    return (
+        <>
+            <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-500' : 'bg-slate-300'} top-0 left-1 dark:bg-slate-700`}></div>
+            {itemIndex !== 0 && (
+                <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-500' : 'bg-slate-300'} -top-1/2 left-1 dark:bg-slate-700`}></div>
+            )}
+            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500' : 'bg-slate-300'} rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 border-white dark:border-gray-900 dark:bg-gray-700 z-10`}></div>
+            {isAtTheStation && (
+                <div className="absolute w-3 h-3 bg-green-400 rounded-full top-1/2 -translate-y-1/2 left-0 dark:bg-gray-700 z-10"></div>
+            )}
+        </>
+    )
+}
+
+export default TrainTimetableTimeline;

--- a/frontend/src/EDR/components/TrainTimetableTimeline.tsx
+++ b/frontend/src/EDR/components/TrainTimetableTimeline.tsx
@@ -9,13 +9,13 @@ type Props = {
 const TrainTimetableTimeline: React.FC<Props> = ({ itemIndex, closestStationIndex, isAtTheStation }) => {
     return (
         <>
-            <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-500' : 'bg-slate-300'} top-0 left-1 dark:bg-slate-700`}></div>
+            <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} top-0 left-1.5`}></div>
             {itemIndex !== 0 && (
-                <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-500' : 'bg-slate-300'} -top-1/2 left-1 dark:bg-slate-700`}></div>
+                <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} -top-1/2 left-1.5`}></div>
             )}
-            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500' : 'bg-slate-300'} rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 border-white dark:border-gray-900 dark:bg-gray-700 z-10`}></div>
+            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} left-0 rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 border-white dark:border-slate-700 z-10`}></div>
             {isAtTheStation && (
-                <div className="absolute w-3 h-3 bg-green-400 rounded-full top-1/2 -translate-y-1/2 left-0 dark:bg-gray-700 z-10"></div>
+                <div className="absolute w-4 h-4 bg-green-400 border-2 border-green-300 rounded-full top-1/2 -translate-y-1/2 left-0 z-10 dark:bg-green-500 dark:border-green-400"></div>
             )}
         </>
     )

--- a/frontend/src/EDR/components/TrainTimetableTimeline.tsx
+++ b/frontend/src/EDR/components/TrainTimetableTimeline.tsx
@@ -9,11 +9,13 @@ type Props = {
 const TrainTimetableTimeline: React.FC<Props> = ({ itemIndex, closestStationIndex, isAtTheStation }) => {
     return (
         <>
-            <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} top-0 left-1.5`}></div>
             {itemIndex !== 0 && (
-                <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} -top-1/2 left-1.5`}></div>
+                <>
+                    <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} top-0 left-1.5`}></div>
+                    <div className={`absolute w-1 h-1/2 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} -top-[45%] left-1.5`}></div>
+                </>
             )}
-            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} left-0 rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 border-white dark:border-slate-700 z-10`}></div>
+            <div className={`absolute w-4 h-4 ${itemIndex <= closestStationIndex ? 'bg-slate-500 dark:bg-slate-200' : 'bg-slate-300 dark:bg-slate-600'} left-0 rounded-full top-1/2 -translate-y-1/2 -left-0.5 border-2 ${itemIndex % 2 ? 'border-gray-50 dark:border-gray-700' : 'border-white dark:border-gray-800' } z-10`}></div>
             {isAtTheStation && (
                 <span className="flex h-4 w-4 absolute left-0 top-1/2 -translate-y-1/2 z-10">
                     <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>


### PR DESCRIPTION
Add feature as requested: https://github.com/simrail/EDR/issues/56

- This PR adds a timeline to each timetable which allow users to track easily where the train is on their path

Dark gray dots: the train passed through.
Light gray dots: the train hasn't passed through.
Green dot: the train is near/at that station.

### Light mode
<img width="1209" alt="Screenshot 2023-02-22 at 16 29 33" src="https://user-images.githubusercontent.com/28097268/220652392-3d5a0b28-858e-4d52-abff-fbed69537cbf.png">

### Dark mode
<img width="1303" alt="Screenshot 2023-02-22 at 16 53 07" src="https://user-images.githubusercontent.com/28097268/220659306-c4eaa64f-d230-4291-bed1-77f2e72467a4.png">

WIP: There is an issue with some stations are not in timetable so I am looking for a solution.
