### PR TITLE
Show traxx passenger trains in selection screen

### DIFF
--- a/frontend/src/SelectMenu/TrainSelect.tsx
+++ b/frontend/src/SelectMenu/TrainSelect.tsx
@@ -87,7 +87,7 @@ export const TrainSelect = () => {
                                 ))}
                             </div>
                             <div className="flex flex-wrap justify-center pt-4">
-                                {trainFilter && trainFilter.filter(t => (t.Vehicles[0].toLowerCase().includes('4e/') && (parseInt(t.TrainNoLocal) >=10000 && parseInt(t.TrainNoLocal) < 100000)) || (parseInt(t.TrainNoLocal) < 10000 && t.Vehicles[0].toLowerCase().includes('4e/'))).map((t) => (
+                                {trainFilter && trainFilter.filter(t => ((t.Vehicles[0].toLowerCase().includes('4e/') || t.Vehicles[0].toLowerCase().includes("traxx")) && parseInt(t.TrainNoLocal) < 100000)).map((t) => (
                                     <TrainCard key={t.TrainNoLocal} train={t} player={players?.find(player => player.steamid === t.TrainData.ControlledBySteamID)} />
                                 ))}
                             </div>


### PR DESCRIPTION
Edit the filter condition of the passenger train row in the train select screen to allow the display of 4E and traxx trains, which operate interchangeably on some lines.

Also simplified the condition, as I think it was redundant. Before it checked for 10000 <= train number < 100000 OR train number < 10000.

Hope I did everything right, and thanks in advance for reviewing

Closes #97 