### PR TITLE
Add development instructions and a docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Of course, we will not send lawyers to your house if you don't follow these rule
 
 Translations are happening via [Transifex](https://explore.transifex.com/simrail-community/edr/). If you wish to participate, we ask that you first contact [@Tallyrald](https://github.com/Tallyrald) via email or on the [Simrail forums](https://forum.simrail.eu/profile/782-crypter-emerald/).
 
+## Developing
+
+Requirements:
+- `docker-compose`
+- `node` and `npm`
+
+Instructions:
+1. Clone or fork this repo
+2. Run `docker-compose up --build` to start the backend
+3. `cd ./frontend`, `npm install` and `npm run start` to start the frontend in development mode
+
 ## Self Hosting
 
 This is a very basic guide, more details may be added later if needed.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -4,7 +4,7 @@ export const BASE_SIMRAIL_API = "https://panel.simrail.eu:8084/";
 export const BASE_AWS_API = "https://api.simrail.eu:8082/api/"
 export const BASE_SIMKOL_API = "https://webhost.simkol.pl/";
 export const BASE_SELF_API = `http://localhost:${process.env.LISTEN_PORT}/`;
-export const BASE_OSRM_API = "http://localhost:5000/";
+export const BASE_OSRM_API = `http://${process.env.OSRM_HOST ?? 'localhost'}:5000/`;
 
 export const srHeaders = {
     "User-Agent": "Simrail.app EDR vDEV",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  backend:
+    build:
+      context: ./backend
+    ports:
+      - "8080:8080"
+    environment: 
+      LISTEN_PORT: 8080
+      OSRM_HOST: 'osrm'
+  osrm:
+    build:
+      context: ./osrm

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -5,7 +5,7 @@ import { TrainTimeTableRow } from "../Sirius";
 import { TimeTableRow } from "../customTypes/TimeTableRow";
 import { ExtendedTrain } from "../customTypes/ExtendedTrain";
 
-export const BASE_API_URL = "http://127.0.0.1/";
+export const BASE_API_URL = process.env.PUBLIC_URL || "http://127.0.0.1:8080/";
 
 const baseApiCall = (URL: string) => {
     // TODO: Add error toast


### PR DESCRIPTION
I like using this app while dispatching, and as I am also a developer I gave it a look.

I found the process of starting the application to be somewhat hard, so I made it easier (and added docs).

I made the following changes:

1. I added `docker-compose.yml`
    - Now all the containers needed for development can be built via a single command.
    - We could create a separate `docker-compose.prod.yml` that will also contain all the setup for `frontend` and `nginx` services.
 This would allow us to remove all the placeholder `example.org` from the `nginx` config.
2. I added the info on how to launch the app to README.
3. I have added a fallback when the developer does not provide a valid `STEAM_API_KEY`:
    - We display the following on failure:
  ![image](https://github.com/simrail/EDR/assets/36668331/111eb04f-d675-443c-98f9-247ef09d3d94)
    - I could remove it if you don't like it
    

I have also noticed that the code is not formatted, maybe we should add and enforce prettier? I could setup github-actions for that if you want.