### PR TITLE
Fix sorting and add +1 day indicator

### DIFF
--- a/frontend/src/EDR/components/Cells/TrainArrivalCell.tsx
+++ b/frontend/src/EDR/components/Cells/TrainArrivalCell.tsx
@@ -3,7 +3,7 @@ import {Badge} from "flowbite-react";
 import {tableCellCommonClassnames} from "../TrainRow";
 import {DetailedTrain} from "../../functions/trainDetails";
 import {useTranslation} from "react-i18next";
-import { format } from "date-fns";
+import { format, isTomorrow } from "date-fns";
 import { TimeTableRow } from "../../../customTypes/TimeTableRow";
 
 type Props = {
@@ -20,10 +20,13 @@ export const TrainArrivalCell: React.FC<Props> = ({
     thirdColRef, streamMode, arrivalTimeDelay
 }) => {
     const {t} = useTranslation();
+    const isTheTrainTommorow = isTomorrow(ttRow.scheduledArrivalObject) 
     return (
         <td className={tableCellCommonClassnames(streamMode)} width="150" ref={thirdColRef}>
             <div className="flex items-center justify-center h-full">
-                {format(ttRow.scheduledArrivalObject, 'HH:mm')}&nbsp;
+                {format(ttRow.scheduledArrivalObject, 'HH:mm')}
+                {isTheTrainTommorow && <sup>+1</sup>}
+                &nbsp;
                 {
                     !trainHasPassedStation && arrivalTimeDelay > 0
                         ? <span

--- a/frontend/src/EDR/index.tsx
+++ b/frontend/src/EDR/index.tsx
@@ -17,7 +17,6 @@ import {redirect, useParams} from "react-router-dom";
 import { useSnackbar } from "notistack";
 import {StringParam, useQueryParam} from "use-query-params";
 import { ISteamUser } from "../config/ISteamUser";
-import { format} from "date-fns";
 import { TrainTimeTableRow } from "../Sirius";
 import { TimeTableRow } from "../customTypes/TimeTableRow";
 import { ExtendedTrain } from "../customTypes/ExtendedTrain";
@@ -85,7 +84,7 @@ export const EDR: React.FC<Props> = ({playSoundNotification, isWebpSupported}) =
             setTzOffset(v[0]);
             setServerTime(v[1]);
             getTimetable(post, serverCode).then((data) => {
-                setTimetable(data.sort((row1, row2) => parseInt(format(row1.scheduledArrivalObject, 'HHmm')) - parseInt(format(row2.scheduledArrivalObject, 'HHmm'))));
+                setTimetable(data.sort((row1, row2) => row1.scheduledArrivalObject.valueOf() - row2.scheduledArrivalObject.valueOf()));
                 getStations(serverCode).then((data) => {
                     setStations(_keyBy('Name', data));
                     getTrainsForPost(serverCode, post).then((data) => {


### PR DESCRIPTION
When playing the game in the evenings, the sorting of the trains is off.

![image](https://github.com/user-attachments/assets/77e9653d-1f8b-4366-a1e6-4aafeafabad7)

The train, which is due to arrive after midnight, is displayed on the top of the list.

This was due to the check only checking the date in `HH:MM` format.

This fixes it to compare the full dates.

![image](https://github.com/user-attachments/assets/343a694f-e5b1-4c2b-aec5-0f7901c799f0)

Additionally, a basic $^{+1}$ indicator was added to the trains that arrive tomorrow. 